### PR TITLE
Reconstruct the comments array if it is not supplied.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,29 @@ exports.parse = parse;
 
 
 function tokenize (code) {
-  return esprima.tokenize(code, {
+  var list = esprima.tokenize(code, {
     comment: true,
     loc: true
   });
+  if (list.comment) {
+    return list;
+  }
+
+  var result = [];
+  var comments = [];
+  list.map(function (t) {
+    if (t.type === 'LineComment') {
+      t.type = 'Line';
+      comments.push(t);
+    } else if (t.type === 'BlockComment') {
+      t.type = 'Block';
+      comments.push(t);
+    } else {
+      result.push(t);
+    }
+  });
+  result.comments = comments;
+  return result;
 }
 
 var tokens;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "chai": "*"
   },
   "dependencies": {
-    "esprima": "~2.6.0"
+    "esprima": "~2.7.0"
   }
 }


### PR DESCRIPTION
With this, it is possible to use node-json-parser with Esprima 2.7 (see also https://github.com/jquery/esprima/issues/1351).